### PR TITLE
Fixed Parachute Deletion Bug

### DIFF
--- a/Yet-Another-Ragdoll-Mod/Main.cs
+++ b/Yet-Another-Ragdoll-Mod/Main.cs
@@ -26,24 +26,31 @@ namespace Yet_Another_Ragdoll_Mod
 
         private void OnTick(object sender, EventArgs e)
         {
-            if (_runRagdoll || (_isSupposedToBeRagdolled && !Game.Player.Character.IsRagdoll))
-            {
-                RunRagdoll();
-            }
-
-            if ((_isSupposedToBeRagdolled && _ragdollConfig.CancelSkydive) 
-                || (Game.Player.Character.IsRagdoll && _ragdollConfig.CancelSkydive))
+            if ((_isSupposedToBeRagdolled || Game.Player.Character.IsRagdoll) && _ragdollConfig.CancelSkydive)
             {
                 Game.Player.Character.Weapons.Remove(WeaponHash.Parachute);
+                ThrowNotification("Deleted Parachute");
             }
 
             if ((Game.Player.Character.IsDead 
-                || Function.Call<bool>(Hash.IS_CUTSCENE_ACTIVE) 
-                || Function.Call<bool>(Hash.IS_PED_IN_ANY_VEHICLE, Game.Player.Character, true))
+                 || Function.Call<bool>(Hash.IS_CUTSCENE_ACTIVE) 
+                 || Function.Call<bool>(Hash.IS_PED_IN_ANY_VEHICLE, Game.Player.Character, true))
                 && _isSupposedToBeRagdolled)
             {
                 ThrowNotification("Caught ragdoll attempt?");
                 _isSupposedToBeRagdolled = false;
+            }
+
+            if (!_ragdollConfig.CancelSkydive && Game.Player.Character.IsRagdoll && _isSupposedToBeRagdolled)
+            {
+                _isSupposedToBeRagdolled = false;
+                ThrowNotification("Set _isSupposedToBeRagdolled to " + _isSupposedToBeRagdolled + " in NOT CancelSkydive check");
+            }
+
+            if (_runRagdoll || (_isSupposedToBeRagdolled && !Game.Player.Character.IsRagdoll))
+            {
+                ThrowNotification("RunRagdoll in Tick Loop hit.");
+                RunRagdoll();
             }
         }
 

--- a/Yet-Another-Ragdoll-Mod/Yet-Another-Ragdoll-Mod.csproj
+++ b/Yet-Another-Ragdoll-Mod/Yet-Another-Ragdoll-Mod.csproj
@@ -8,7 +8,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Yet_Another_Ragdoll_Mod</RootNamespace>
-    <AssemblyName>Yet_Another_Ragdoll_Mod</AssemblyName>
+    <AssemblyName>Yet-Another-Ragdoll-Mod</AssemblyName>
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>

--- a/Yet-Another-Ragdoll-Mod/Yet-Another-Ragdoll-Mod.ini
+++ b/Yet-Another-Ragdoll-Mod/Yet-Another-Ragdoll-Mod.ini
@@ -5,4 +5,4 @@ RagdollEndDelay = 1.0 //Time after input is pressed before the Ragdoll is ended
 CancelSkydive = true //Overrides entering skydiving when falling far enough in ragdoll
 
 [DebugConfig]
-ShowDebugNotifications = false //Shows debugging notifications - recommended false
+ShowDebugNotifications = false //Shows debugging notifications - highly recommended false


### PR DESCRIPTION
Problem stemmed from mismatched naming of DLL and Config files (was originally `_` instead of `-`).

Resolves #4.